### PR TITLE
Update: change cdap-data version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,13 @@
 
   <properties>
     <!-- properties for script build step that creates the config files for the artifacts -->
-    <data.pipeline.parent>system:cdap-data-pipeline[6.1.1,7.0.0-SNAPSHOT)</data.pipeline.parent>
-    <data.stream.parent>system:cdap-data-streams[6.1.1,7.0.0-SNAPSHOT)</data.stream.parent>
+    <data.pipeline.parent>system:cdap-data-pipeline[6.1.2,7.0.0-SNAPSHOT)</data.pipeline.parent>
+    <data.stream.parent>system:cdap-data-streams[6.1.2,7.0.0-SNAPSHOT)</data.stream.parent>
 
     <cdap.version>6.1.2</cdap.version>
     <spark.version>2.1.3</spark.version>
     <logback.version>1.0.9</logback.version>
+    <guava.version>13.0.1</guava.version>
 
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
   </properties>
@@ -145,6 +146,11 @@
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/io/cdap/plugin/WindowAggregationConfig.java
+++ b/src/main/java/io/cdap/plugin/WindowAggregationConfig.java
@@ -18,13 +18,13 @@ package io.cdap.plugin;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.plugin.PluginConfig;
-import org.apache.parquet.Strings;
 import org.apache.spark.sql.Column;
 
 import java.util.ArrayList;


### PR DESCRIPTION
@CuriousVini 

This PR includes the increase version of cdap-data required in PR: https://github.com/cdapio/hub/pull/411

In addition to this, while testing the changes we found out that validation button is having issues: 

```
 CDAP v6.3.0:  Exception encountered while processing request : org/apache/spark/api/java/function/Function
 CDAP v6.1.3:  Exception encountered while processing request : org/apache/spark/sql/expressions/UserDefinedAggregateFunction
```

this is as result of the scope change of the dependency ``spark-repl_2.11`` to **provided** 

https://github.com/AdaptiveScale/window-aggregation/blob/080dc35af3f482e20ba4c8338a5ef328324c03b0/pom.xml#L58
