### PR TITLE
PLUGIN-1308: Fix collect() being called in Window Aggregations

### DIFF
--- a/src/main/java/io/cdap/plugin/WindowsAggregationUtil.java
+++ b/src/main/java/io/cdap/plugin/WindowsAggregationUtil.java
@@ -87,12 +87,10 @@ final class WindowsAggregationUtil {
     String numberOfPartitionsString = config.getNumberOfPartitions();
 
     if (Strings.isNullOrEmpty(numberOfPartitionsString)) {
-      return sparkExecutionPluginContext.getSparkContext()
-        .parallelize(rowJavaRDD.collect());
+      return rowJavaRDD;
     }
 
-    return sparkExecutionPluginContext.getSparkContext().parallelize(rowJavaRDD.collect(),
-                                                                     Integer.parseInt(numberOfPartitionsString));
+    return rowJavaRDD.repartition(Integer.parseInt(numberOfPartitionsString));
   }
 
   private static Dataset<Row> applyCustomFunction(SQLContext sqlContext, WindowAggregationConfig.FunctionInfo


### PR DESCRIPTION
This PR removes the calls to `collect()` in the Window Aggregations, replacing them with standard RDD returns.