### PR TITLE
Test for WindowFrame response of WindowSpec of Apache Spark for Preceding and Following values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,57 +103,6 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>hydrator-test</artifactId>
-      <version>${cdap.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>io.cdap.cdap</groupId>
-          <artifactId>cdap-unit-test</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-unit-test-spark2_2.11</artifactId>
-      <version>${cdap.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.cdap.cdap</groupId>
-          <artifactId>cdap-explore-jdbc</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
-      <version>${cdap.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <version>${logback.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>${logback.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-api-common</artifactId>
       <version>${cdap.version}</version>
       <scope>provided</scope>
@@ -181,6 +130,12 @@
       <artifactId>mockito-inline</artifactId>
       <version>4.8.1</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/io/cdap/plugin/WindowsAggregationUtil.java
+++ b/src/main/java/io/cdap/plugin/WindowsAggregationUtil.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.plugin;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
@@ -197,7 +198,8 @@ final class WindowsAggregationUtil {
     return schemaField.getSchema();
   }
 
-  private static Column[] getPartitionsColumns(List<String> partitionsFields) {
+  @VisibleForTesting
+  public static Column[] getPartitionsColumns(List<String> partitionsFields) {
     return partitionsFields.stream().map(Column::new).toArray(Column[]::new);
   }
 


### PR DESCRIPTION
![Screenshot 2022-11-21 5 59 47 PM](https://user-images.githubusercontent.com/109594513/203055678-2a081422-af42-4231-a6a4-69d0d3a07430.png)
The windowFrame property of WindowSpec in Apache Spark returns a response 
eg: " 1 Following and 2 Following".   In the above screen shot of CDAP Window Aggregation Analytics, we have options to choose 
1.Unbounded Preceding and VALUE Following 
2.VALUE Preceding and  Unbounded Following 
3.VALUE Preceding and VALUE Following
4.Unbounded Preceding and Unbounded Following .
But Not
1.VALUE Preceding and VALUE Preceding
2.VALUE Following and VALUE Following
Since WindowFrame property is private in Window Spec ,to assert the response used reflect method.
 **Positive** number in **preceding** field input  gives the  response **NUMBER** **following** and **Negative** number in **following** field input gives response **NUMBER** **preceding** This test case is to make sure that we are aware of the current scenario where a positive preceding value is taken as a following and negative following value is taken as preceding.Also removed the dependencies in pom.xml which are not necessary