### PR TITLE
PLUGIN-1574 : Adding validation for different clauses and params

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>window-aggregator</artifactId>
-  <version>1.0.3-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
 
   <properties>
     <!-- properties for script build step that creates the config files for the artifacts -->

--- a/src/test/java/io/cdap/plugin/WindowAggregationTest.java
+++ b/src/test/java/io/cdap/plugin/WindowAggregationTest.java
@@ -47,7 +47,8 @@ import static org.mockito.Mockito.mock;
 
 public class WindowAggregationTest {
   List<String> partitionFields;
-  String partitionOrderFields;
+  List<String> partitionOrderFields;
+  String partitionOrder;
   List<WindowAggregationConfig.FunctionInfo> functionInfos;
   WindowAggregationConfig.WindowFrameType windowFrameType;
   @Mock
@@ -83,7 +84,9 @@ public class WindowAggregationTest {
     partitionFields = new ArrayList<>();
     partitionFields.add("field");
     partitionFields.add("field2");
-    partitionOrderFields  = "field:Ascending";
+    partitionOrder = "field:Ascending";
+    partitionOrderFields = new ArrayList<>();
+    partitionOrderFields.add(partitionOrder);
     long dummy = 0;
     config = mock(WindowAggregationConfig.class);
     function = WindowAggregationConfig.Function.FIRST;
@@ -96,7 +99,8 @@ public class WindowAggregationTest {
     relationalTranformContext = mock(RelationalTranformContext.class);
     Mockito.when(config.getPartitionFields()).thenReturn(partitionFields);
     Mockito.when(relationalTranformContext.getEngine()).thenReturn(engine);
-    Mockito.when(config.getPartitionOrder()).thenReturn(partitionOrderFields);
+    Mockito.when(config.getPartitionOrder()).thenReturn(partitionOrder);
+    Mockito.when(config.getPartitionOrderFields()).thenReturn(partitionOrderFields);
     Mockito.when(config.getWindowFrameType()).thenReturn(windowFrameType);
     Mockito.when(config.isFrameDefinitionUnboundedPreceding()).thenReturn(false);
     Mockito.when(config.isFrameDefinitionUnboundedFollowing()).thenReturn(false);


### PR DESCRIPTION
Change Notes : 

1. Validation for all 3 clauses for every function according to : 

+-------------------------+-----------+---------------+---------------+
|                                             | partition     | ordering           | frametype        |
+-------------------------+-----------+---------------+---------------+
| rank                                    | required     | required            | not_supported |
+-------------------------+-----------+---------------+---------------+
| dense_rank                        | required     | required            |not_supported |
+-------------------------+-----------+---------------+---------------+
| percent_rank                     | required     | required            | not_supported |
+-------------------------+-----------+---------------+---------------+
| n_tile                                  | required.    | required            | not_supported |
+-------------------------+-----------+---------------+---------------+
| row_number                      | required     | required            | not_supported |
+-------------------------+-----------+---------------+---------------+
| continous_percentile        | required    | not_supported | not_supported |
+-------------------------+-----------+---------------+---------------+
| discrete_percentile           | required     | not_supported | not_supported |
+-------------------------+-----------+---------------+---------------+
| lead                                    | required     | required            | not_supported |
+-------------------------+-----------+---------------+---------------+
| lag                                       | required    | required            | not_supported |
+-------------------------+-----------+---------------+---------------+
| first                                     | required     | required            | optional            |
+-------------------------+-----------+---------------+---------------+
| last                                     | required      | required           | optional             |
+-------------------------+-----------+---------------+---------------+
| cumulative_distribution    | required     | required           | not_supported |
+-------------------------+-----------+---------------+---------------+
| accumulate                        | required     | optional            | optional            |
+-------------------------+-----------+---------------+---------------+

3. Currently `partition is Mandatory in plugin`. But that is not true for multiple functions in SQL. This PR considers this and can support `partition` field as `optional` with 1 line code change. 

4. Validation of Special case  : 

When using `Accumulate` with frametype `RANGE`, then there has to be Exactly 1 ordering clause. 

5. Validation of Argument field of each function. 
The following function will take arg according to : 

|                                        | argument                                  | constraint                            |
|-----------------------+------------------------------|---------------------------|
| n_tile                             | constant_integer_expression |   INT type, greater than 0   |
| continous_percentile  | percentile                                  |  float between 0,1               |
| discrete_percentile     | percentile                                  |   float between 0,1              |
| lead                              | offset                                          |   non-negative INT             |

