### PR TITLE
[PLUGIN-1900] Added a fix for invalid schema while using multiple functions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,12 @@ jobs:
          && (github.event.action != 'labeled' || github.event.label.name == 'build')
          )
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
     steps:
     # Pinned 1.0.0 version
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: plugin
     - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
@@ -56,34 +56,33 @@ jobs:
           e2e-test:
             - '**/e2e-test/**'
     - name: Checkout e2e test repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: cdapio/cdap-e2e-tests
         path: e2e
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-${{ github.workflow }}
     - name: Run all e2e tests
-      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || steps.filter.outputs.e2e-test == 'true'
       run: python3 e2e/src/main/scripts/run_e2e_test.py
     - name: Upload report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: Cucumber report - window aggregation
         path: ./plugin/target/cucumber-reports
     - name: Upload debug files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: Debug files - window aggregation
         path: ./**/target/e2e-debug
     - name: Upload files to GCS
-      uses: google-github-actions/upload-cloud-storage@v0
+      uses: google-github-actions/upload-cloud-storage@v2
       if: always()
       with:
         path: ./plugin/target/cucumber-reports

--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
         <dependency>
           <groupId>io.cdap.tests.e2e</groupId>
           <artifactId>cdap-e2e-framework</artifactId>
-          <version>0.3.0-SNAPSHOT</version>
+          <version>0.5.0-SNAPSHOT</version>
           <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/cdap/plugin/WindowAggregation.java
+++ b/src/main/java/io/cdap/plugin/WindowAggregation.java
@@ -132,7 +132,7 @@ public class WindowAggregation extends SparkCompute<StructuredRecord, Structured
     stageConfigurer.setOutputSchema(getOutputSchema(inputSchema, aggregates));
   }
 
-  private void validate(Schema inputSchema, FailureCollector collector,
+  protected void validate(Schema inputSchema, FailureCollector collector,
                         List<WindowAggregationConfig.FunctionInfo> aggregates) {
     List<String> partitionFields = config.getPartitionFields();
     List<String> partitionOrderFields = config.getPartitionOrderFields();
@@ -188,8 +188,8 @@ public class WindowAggregation extends SparkCompute<StructuredRecord, Structured
         }
       }
 
-      if (function.getOutputSchema() == null && inputFieldSchema != null) {
-        function.setOutputSchema(inputFieldSchema);
+      if (functionInfo.getOutputSchema() == null && inputFieldSchema != null) {
+       functionInfo.setOutputSchema(inputFieldSchema);
       }
     }
 
@@ -358,14 +358,14 @@ public class WindowAggregation extends SparkCompute<StructuredRecord, Structured
     }
   }
 
-  private Schema getOutputSchema(Schema inputSchema, List<WindowAggregationConfig.FunctionInfo> aggregates) {
+  protected Schema getOutputSchema(Schema inputSchema, List<WindowAggregationConfig.FunctionInfo> aggregates) {
     List<Schema.Field> outputFields = new ArrayList<>(aggregates.size());
     List<Schema.Field> inputSchemaFields = inputSchema.getFields();
     if (inputSchemaFields != null) {
       outputFields.addAll(inputSchemaFields);
     }
     for (WindowAggregationConfig.FunctionInfo aggregate : aggregates) {
-      outputFields.add(Schema.Field.of(aggregate.getAlias(), aggregate.getFunction().getOutputSchema()));
+      outputFields.add(Schema.Field.of(aggregate.getAlias(), aggregate.getOutputSchema()));
     }
     return Schema.recordOf(inputSchema.getRecordName() + ".window", outputFields);
   }

--- a/src/main/java/io/cdap/plugin/WindowAggregationConfig.java
+++ b/src/main/java/io/cdap/plugin/WindowAggregationConfig.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
@@ -107,6 +108,24 @@ public class WindowAggregationConfig extends PluginConfig {
   @Nullable
   @Description("Specifies the schema of the records outputted from this plugin.")
   private String schema;
+
+  @VisibleForTesting
+  public WindowAggregationConfig(String partitionFields, @Nullable String partitionOrder,
+                                 @Nullable String windowFrameType, @Nullable Boolean unboundedPreceding,
+                                 @Nullable Boolean unboundedFollowing, @Nullable String preceding,
+                                 @Nullable String following, String aggregates, @Nullable String numberOfPartitions,
+                                 @Nullable String schema) {
+    this.partitionFields = partitionFields;
+    this.partitionOrder = partitionOrder;
+    this.windowFrameType = windowFrameType;
+    this.unboundedPreceding = unboundedPreceding;
+    this.unboundedFollowing = unboundedFollowing;
+    this.preceding = preceding;
+    this.following = following;
+    this.aggregates = aggregates;
+    this.numberOfPartitions = numberOfPartitions;
+    this.schema = schema;
+  }
 
   private static Schema numericSchema() {
     return Schema.unionOf(Schema.of(Schema.Type.INT), Schema.of(Schema.Type.DOUBLE), Schema.of(Schema.Type.LONG),
@@ -437,10 +456,6 @@ public class WindowAggregationConfig extends PluginConfig {
       return outputSchema;
     }
 
-    public void setOutputSchema(Schema outputSchema) {
-      this.outputSchema = outputSchema;
-    }
-
     public ClauseConstraint getPartitioning() {
       return partitioning;
     }
@@ -463,6 +478,9 @@ public class WindowAggregationConfig extends PluginConfig {
     private final String alias;
     private final String[] args;
     private final boolean ignoreNull;
+    // Added 'schema' of Function enum to 'FunctionInfo' also because its value can be dynamic for some instances,
+    // and storing it directly in the enum caused unintended sharing across objects.
+    private Schema outputSchema;
 
     public FunctionInfo(String alias, Function function, String fieldName, String[] arguments, String ignoreNulls) {
       this.alias = alias;
@@ -470,6 +488,7 @@ public class WindowAggregationConfig extends PluginConfig {
       this.fieldName = fieldName;
       this.args = arguments;
       this.ignoreNull = !"false".equals(ignoreNulls);
+      this.outputSchema = function.getOutputSchema();
     }
 
     public Function getFunction() {
@@ -495,6 +514,14 @@ public class WindowAggregationConfig extends PluginConfig {
     public String description() {
       return String.format("%s:%s(%s,%s,%s)", getAlias(), getFunction().name(), getFieldName(),
         Joiner.on(",").join(args), ignoreNull);
+    }
+
+    public Schema getOutputSchema() {
+      return outputSchema;
+    }
+
+    public void setOutputSchema(Schema outputSchema) {
+      this.outputSchema = outputSchema;
     }
   }
 }

--- a/src/test/java/io/cdap/plugin/WindowAggregationTest.java
+++ b/src/test/java/io/cdap/plugin/WindowAggregationTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -124,7 +125,7 @@ public class WindowAggregationTest {
     sparkExecutionPluginContext = mock(SparkExecutionPluginContext.class);
     Mockito.when(sparkExecutionPluginContext.getFailureCollector()).thenReturn(failureCollector);
     Mockito.when(sparkExecutionPluginContext.getInputSchema()).thenReturn(schema);
-    function.setOutputSchema(schema);
+    functionInfo.setOutputSchema(schema);
     stageConfigurer = mock(StageConfigurer.class);
     pipelineConfigurer = mock(PipelineConfigurer.class);
     Mockito.when(pipelineConfigurer.getStageConfigurer()).thenReturn(stageConfigurer);
@@ -342,5 +343,24 @@ public class WindowAggregationTest {
         windowAggregation.getColumnSelectionExpression(func, "colname"));
   }
 
+  @Test
+  public void getLeadFunctionSchema_multiple_fields() throws IOException {
+    String schema = "{\"type\":\"record\",\"name\":\"fileRecord\",\"fields\":[{\"name\":\"field2\",\"type\":\"int\"}" +
+      ",{\"name\":\"field\",\"type\":\"string\"}]}";
+    Schema inputSchema = Schema.parseJson(schema);
+    WindowAggregationConfig windowAggregationConfig = new WindowAggregationConfig("field", "field:asc",
+                                                                                  null, null, null, null, null,
+                                                                                  "prevField:lead(field,1,false)\n" +
+                                                                                    "prevField2:lead(field2,1,false)",
+                                                                                  null, schema);
+    List<WindowAggregationConfig.FunctionInfo> aggregates = windowAggregationConfig.getAggregates(failureCollector);
+    WindowAggregation windowAggregation = new WindowAggregation(windowAggregationConfig);
+    windowAggregation.validate(inputSchema, failureCollector, aggregates);
+    Schema outputSchema = windowAggregation.getOutputSchema(inputSchema, aggregates);
+    Assert.assertEquals(outputSchema.getFields().size(), 4);
+    Assert.assertEquals(outputSchema.getField("field").getSchema(),
+                        outputSchema.getField("prevField").getSchema());
+    Assert.assertEquals(outputSchema.getField("field2").getSchema(),
+                        outputSchema.getField("prevField2").getSchema());
+  }
 }
-


### PR DESCRIPTION
[PLUGIN-1900] Added a fix for invalid schema while using multiple functions and schema type is different for fields. It is setting first field type to all later field types.

Added 'schema' of Function enum to 'FunctionInfo' also because its value can be dynamic for some instances, and storing it directly in the enum caused unintended sharing across objects.

Before: 
<img width="1512" alt="Screenshot 2025-06-18 at 9 06 39 PM" src="https://github.com/user-attachments/assets/1547c9ac-0daa-4090-a1b1-d92cb00396a1" />

After:
<img width="1503" alt="Screenshot 2025-06-18 at 9 08 46 PM" src="https://github.com/user-attachments/assets/f644c062-d86b-4475-aea9-cfdc969a0e03" />

    

[PLUGIN-1900]: https://cdap.atlassian.net/browse/PLUGIN-1900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ